### PR TITLE
Make sandbox configurable on the client

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,23 +14,25 @@ const pdfShiftURL = "https://api.pdfshift.io/v2/convert"
 
 // PDFShift represents the
 type PDFShift struct {
-	apiKey string
-	client *http.Client
-	url    string
+	apiKey  string
+	client  *http.Client
+	sandbox bool
+	url     string
 }
 
 // New returns a new PDFShift client
-func New(key string) *PDFShift {
+func New(key string, sandbox bool) *PDFShift {
 	return &PDFShift{
-		apiKey: key,
-		client: &http.Client{},
-		url:    pdfShiftURL,
+		apiKey:  key,
+		client:  &http.Client{},
+		sandbox: sandbox,
+		url:     pdfShiftURL,
 	}
 }
 
 // Convert sends a request to PDFShift to preform the conversion
 func (c *PDFShift) Convert(ctx context.Context, rb *PDFBuilder) ([]byte, error) {
-	encoded, err := rb.build().convert()
+	encoded, err := rb.sandbox(c.sandbox).build().convert()
 	if err != nil {
 		return nil, vice.Wrap(err, vice.InvalidArgument, "unable to marshal conversion message")
 	}

--- a/request.go
+++ b/request.go
@@ -171,8 +171,8 @@ func (rb *PDFBuilder) Protection(p Protection) *PDFBuilder {
 	return rb.set("protection", p.encode())
 }
 
-// Sandbox sets the PDF conversion to happen in the PDFShift sandbox
-func (rb *PDFBuilder) Sandbox(enabled bool) *PDFBuilder {
+// sandbox sets the PDF conversion to happen in the PDFShift sandbox
+func (rb *PDFBuilder) sandbox(enabled bool) *PDFBuilder {
 	return rb.set("sandbox", enabled)
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -212,7 +212,7 @@ func TestPDFBuilder_Protection(t *testing.T) {
 
 func TestPDFBuilder_Sandbox(t *testing.T) {
 	p := NewPDFBuilder()
-	p.Sandbox(true)
+	p.sandbox(true)
 	b := p.build()
 
 	if b["sandbox"].(bool) != true {


### PR DESCRIPTION
This makes `sandbox` set at the client level, as it makes more sense to configure it per env and not per request.